### PR TITLE
added universal translator function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "liveServer.settings.port": 5503
+    "liveServer.settings.port": 5504
 }

--- a/index.html
+++ b/index.html
@@ -16,14 +16,9 @@
   <body>
     
     <header>
-      
-      <div class="jumbotron">
-        <h1 class="">Novonom Lingo</h1>
-    </div>
-
-      <!-- <div class= "title">
-          <h1 class="btn btn-outline-light">Novonom Lingo</h1>
-      </div> -->
+      <div>
+          <h1 class="btn-outline-light">Novonom Lingo</h1>
+      </div>
     </header>
 
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -53,6 +48,9 @@
             </li>
             <li id="mandarin" class="nav-item nav-link">
               <a href="#">Mandarin</a>
+            </li>
+            <li id="universal" class="nav-item nav-link">
+              <a href="#">Universal Language Translator</a>
             </li>
           </ul>
         </div>
@@ -119,6 +117,7 @@
     <script src="scripts/hindi.js"></script>
     <script src="scripts/mandarin.js"></script>
     <script src="scripts/spanish.js"></script>
+    <script src="scripts/universal-lang.js"></script>
 
   </body>
 </html>

--- a/scripts/domPrinter.js
+++ b/scripts/domPrinter.js
@@ -167,6 +167,35 @@ function buildTranslatorContainer (languageName) {
     </footer>`
 }
 
+function buildUniversalTranslatorContainer () {
+  return`
+  <footer class = "page-footer font-small blue pt-4">
+  <div class = "row">
+      <div class = "col-sm" id = "translator-container">
+          <input id = "user-input" type= "text" placeholder= "Enter text">
+          <button id= "translate-btn-universal" class="btn btn-primary auto">Translate</button>
+      </div>
+  </div>
+  </footer>`
+}
+
+function buildLanguageOptionsContainer (labelName, selectIDAddOn) {
+  let languageArray = Object.keys(languageCodesObject)
+  let languageOptionsHTMLString = `<div class = "row">
+  <div class = "col-sm" id = "language-options">
+    <label for = "languages">${labelName}</label>
+      <select id= "language-selector-${selectIDAddOn}">`
+
+    for (let i = 0; i < languageArray.length; i++){
+      languageOptionsHTMLString += `<option>${languageArray[i]}</option>`
+    }
+
+  languageOptionsHTMLString += `</select>
+  </div>`
+
+  return languageOptionsHTMLString
+}
+
 
 //Function that matches a phrase entered through user input to a key from the language's dictionary; returns that key
 function translate () {
@@ -241,4 +270,24 @@ function textToSpeechFunction (languageName, toBeTranslatedValue, translatedPhra
         speechSynthesis.speak(utterance)
     }
 
+}
+
+//Function for universal Translator API
+const apiFetch = {
+  getAll: (text, languageFrom, languageTo) => {
+      fetch(`https://translate.yandex.net/api/v1.5/tr.json/translate?key=trnsl.1.1.20200420T153316Z.67b81eb3be4a746e.9ef97414c4d9092d1fa3de6691239ca6795ce0cb&text=${text}&lang=${languageFrom}-${languageTo}&format=html
+      `)
+      .then(r => r.json())
+      .then(pr => pr.text.forEach(element => {
+      document.querySelector("#translator-container").innerHTML +=         
+      `<div id = "phrase-container" class = "row">
+      <p>The phrase <strong><em>${text}</em></strong> translates to <strong><em>${element}</em></strong></p>
+      </div>`
+      let utterance = new SpeechSynthesisUtterance(`The phrase ${text} translates to ${element}`)
+
+      utterance.lang = languageTo
+      speechSynthesis.cancel();
+      speechSynthesis.speak(utterance)
+      }))
+  }
 }

--- a/scripts/french.js
+++ b/scripts/french.js
@@ -59,20 +59,38 @@ document.querySelector("#french").addEventListener("click", function(){
 
 })
 
-// French translator click event
+// French translator click event with limited dictionary
+// document.querySelector("#language-container").addEventListener("click", function(){
+//   if(event.target.id === "translate-btn-french"){
+
+//     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
+
+//     const translatedPhrase = frenchData.dictionary[translate()]
+
+//     if (translatedPhrase !== undefined){
+//       document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
+
+//       textToSpeechFunction(frenchData.name, toBeTranslatedValue, translatedPhrase)
+//     }
+//   }
+// })
+
+//Translator using API
 document.querySelector("#language-container").addEventListener("click", function(){
   if(event.target.id === "translate-btn-french"){
-
     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
 
-    const translatedPhrase = frenchData.dictionary[translate()]
-
-    if (translatedPhrase !== undefined){
-      document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
-
-      textToSpeechFunction(frenchData.name, toBeTranslatedValue, translatedPhrase)
+    if(toBeTranslatedValue !== ""){
+      apiFetch.getAll(toBeTranslatedValue, "en", "fr")
     }
-  }
+    else{
+      const translatedPhrase = "I'm sorry, the phrase you entered is not in our dictionary! Please, try another phrase :)"
+      speechSynthesis.speak(new SpeechSynthesisUtterance(translatedPhrase))
+      document.querySelector("#translator-container").innerHTML += `
+      <p>${translatedPhrase}</p>`
+    }
+
+    }
 })
 
 // Navbar Home button click event

--- a/scripts/hindi.js
+++ b/scripts/hindi.js
@@ -69,19 +69,36 @@ document.querySelector("#hindi").addEventListener("click", function(){
   // Translator print
   document.querySelector("#language-container").innerHTML += buildTranslatorContainer(hindiData.name.toLowerCase())
 
-// Hindi translator click event
+// Hindi translator click event w/ dictionary
+// document.querySelector("#language-container").addEventListener("click", function(){
+//   if(event.target.id === "translate-btn-hindi"){
+
+//     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
+
+//     const translatedPhraseObject = hindiData.dictionary[translate()]
+
+//     if (translatedPhraseObject !== undefined){
+//       const translatedPhrase = translatedPhraseObject.englishPronunciation
+//       document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
+
+//       textToSpeechFunction(hindiData.name, toBeTranslatedValue, translatedPhrase)
+//     }
+//     }
+// })
+
+//Translator click event with Translator API
 document.querySelector("#language-container").addEventListener("click", function(){
   if(event.target.id === "translate-btn-hindi"){
-
     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
 
-    const translatedPhraseObject = hindiData.dictionary[translate()]
-
-    if (translatedPhraseObject !== undefined){
-      const translatedPhrase = translatedPhraseObject.englishPronunciation
-      document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
-
-      textToSpeechFunction(hindiData.name, toBeTranslatedValue, translatedPhrase)
+    if(toBeTranslatedValue !== ""){
+      apiFetch.getAll(toBeTranslatedValue, "en", "hi")
+    }
+    else{
+      const translatedPhrase = "I'm sorry, the phrase you entered is not in our dictionary! Please, try another phrase :)"
+      speechSynthesis.speak(new SpeechSynthesisUtterance(translatedPhrase))
+      document.querySelector("#translator-container").innerHTML += `
+      <p>${translatedPhrase}</p>`
     }
     }
 })

--- a/scripts/mandarin.js
+++ b/scripts/mandarin.js
@@ -50,19 +50,38 @@ const mandarinData = {
     
   })
   
-  // Mandarin translator click event
+  // Mandarin translator click event w/ limited dictionary
+  // document.querySelector("#language-container").addEventListener("click", function(){
+  //   if(event.target.id === "translate-btn-mandarin"){
+  
+  //     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
+  
+  //     const translatedPhrase = mandarinData.dictionary[translate()]
+  
+  //     if (translatedPhrase !== undefined){
+  //       document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
+
+  //       textToSpeechFunction(mandarinData.name, toBeTranslatedValue, translatedPhrase)
+  //     }
+  //   }
+  // })
+
+
+  //Translator click event with API
   document.querySelector("#language-container").addEventListener("click", function(){
     if(event.target.id === "translate-btn-mandarin"){
-  
       const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
   
-      const translatedPhrase = mandarinData.dictionary[translate()]
-  
-      if (translatedPhrase !== undefined){
-        document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
-
-        textToSpeechFunction(mandarinData.name, toBeTranslatedValue, translatedPhrase)
+      if(toBeTranslatedValue !== ""){
+        apiFetch.getAll(toBeTranslatedValue, "en", "zh")
       }
-    }
+      else{
+        const translatedPhrase = "I'm sorry, the phrase you entered is not in our dictionary! Please, try another phrase :)"
+        speechSynthesis.speak(new SpeechSynthesisUtterance(translatedPhrase))
+        document.querySelector("#translator-container").innerHTML += `
+        <p>${translatedPhrase}</p>`
+      }
+  
+      }
   })
 

--- a/scripts/spanish.js
+++ b/scripts/spanish.js
@@ -60,18 +60,36 @@ document.querySelector("#spanish").addEventListener("click", function(){
 
 })
 
-// Spanish translator click event
+// Spanish translator click event w/ limited dictionary
+// document.querySelector("#language-container").addEventListener("click", function(){
+//   if(event.target.id === "translate-btn-spanish"){
+
+//     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
+
+//     const translatedPhrase = spanishData.dictionary[translate()]
+
+//     if (translatedPhrase !== undefined){
+//       document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
+
+//       textToSpeechFunction(spanishData.name, toBeTranslatedValue, translatedPhrase)
+//     }
+//   }
+// })
+
+//Translator click event with API
 document.querySelector("#language-container").addEventListener("click", function(){
   if(event.target.id === "translate-btn-spanish"){
-
     const toBeTranslatedValue = document.querySelector("#text-area").value.toLowerCase()
 
-    const translatedPhrase = spanishData.dictionary[translate()]
-
-    if (translatedPhrase !== undefined){
-      document.querySelector("#translator-container").innerHTML += buildTranslatedPhraseContainer(toBeTranslatedValue, translatedPhrase)
-
-      textToSpeechFunction(spanishData.name, toBeTranslatedValue, translatedPhrase)
+    if(toBeTranslatedValue !== ""){
+      apiFetch.getAll(toBeTranslatedValue, "en", "es")
     }
-  }
+    else{
+      const translatedPhrase = "I'm sorry, the phrase you entered is not in our dictionary! Please, try another phrase :)"
+      speechSynthesis.speak(new SpeechSynthesisUtterance(translatedPhrase))
+      document.querySelector("#translator-container").innerHTML += `
+      <p>${translatedPhrase}</p>`
+    }
+
+    }
 })

--- a/scripts/universal-lang.js
+++ b/scripts/universal-lang.js
@@ -1,0 +1,136 @@
+const languageCodesObject = {
+    Azerbaijan:	 "az",
+        Afrikaans:	  "af",
+        Albanian:	 "sq",
+        Amharic:	  "am", 
+        Arabic:	 "ar", 
+        Armenian:	 "hy",
+        Bashkir:	  "ba",
+        Basque:	 "eu",
+        Belarusian:	 "be", 
+        Bengali:	  "bn", 
+        Bosnian:	  "bs", 
+        Bulgarian:	  "bg", 
+        Burmese:	  "my", 
+        Catalan:	  "ca", 
+        Cebuano:	  "ceb",
+        Chinese:	  "zh", 
+        Croatian:	 "hr",
+        Czech:	  "cs",
+        Danish:	 "da", 
+        Dutch:	  "nl", 
+        English:	  "en", 
+        Esperanto:	  "eo",
+        Estonian:	 "et",
+        Finnish:	  "fi",
+        French:	 "fr",
+        Galician:	 "gl",
+        Georgian:	 "ka",
+        German:	 "de",
+        Greek:	  "el",
+        Gujarati:	 "gu",
+        Haitian:	 "ht",
+        Hebrew:	 "he", 
+        Hill_Mari:	  "mrj",
+        Hindi:	  "hi",
+        Hungarian:	  "hu", 
+        Icelandic:	  "is", 
+        Indonesian:	 "id",
+        Irish:	  "ga", 
+        Italian:	  "it", 
+        Japanese:	 "ja",
+        Javanese:	 "jv",
+        Kannada:	  "kn", 
+        Kazakh:	 "kk", 
+        Khmer:	  "km", 
+        Korean:	 "ko", 
+        Kyrgyz:	 "ky", 
+        Laotian:	  "lo", 
+        Latin:	  "la", 
+        Latvian:	  "lv", 
+        Lithuanian:	 "lt", 
+        Luxembourgish:	  "lb", 
+        Macedonian:	 "mk",
+        Malagasy:	 "mg", 
+        Malay:	  "ms",  
+        Malayalam:	  "ml",
+        Maltese:	  "mt",
+        Maori:	  "mi",
+        Marathi:	  "mr",
+        Mari:	 "mhr",
+        Mongolian:	  "mn",
+        Nepali:	 "ne",
+        Norwegian:	  "no",
+        Papiamento:	 "pap",
+        Persian:	  "fa",
+        Polish:	 "pl",
+        Portuguese:	 "pt",
+        Punjabi:	  "pa",
+        Romanian:	 "ro",
+        Russian:	  "ru",
+        Scottish:	 "gd",
+        Serbian:	  "sr",
+        Sinhala:	  "si",
+        Slovakian:	  "sk",
+        Slovenian:	  "sl",
+        Spanish:	  "es", 
+        Sundanese:	  "su",
+        Swahili:	  "sw",
+        Swedish:	  "sv",
+        Tagalog:	  "tl",
+        Tajik:	  "tg",
+        Tamil:	  "ta",
+        Tatar:	  "tt",
+        Telugu:	 "te",
+        Thai:	 "th",
+        Turkish:	  "tr",
+        Udmurt:	 "udm",
+        Ukrainian:	  "uk",
+        Urdu:	 "ur",
+        Uzbek:	  "uz",
+        Vietnamese:	 "vi", 
+        Welsh:	  "cy",
+        Xhosa:	  "xh", 
+        Yiddish:	  "yi",
+    
+    }
+  //Creating DOM content: heading, language options containers and translator container
+    document.querySelector("#universal").addEventListener("click", function(){
+  
+      document.querySelector("#language-container").classList.add("container")
+  
+      document.querySelector("#language-container").innerHTML = `<div class="jumbotron d-flex justify-content-center h-25 d-inline-block">
+      <h1 class="universal-lang-heading" >Universal Language Translator</h1>
+          </div>`
+  
+      document.querySelector("#language-container").innerHTML += buildLanguageOptionsContainer("Select language to translate phrase from:", "from")
+  
+      document.querySelector("#language-container").innerHTML += buildLanguageOptionsContainer("Select language to translate phrase to:", "to")
+  
+      document.querySelector("#language-container").innerHTML += buildUniversalTranslatorContainer()
+    })
+  
+  //Universal Translator using API
+    document.querySelector("#language-container").addEventListener("click", function(){
+      if(event.target.id === "translate-btn-universal"){
+        const toBeTranslatedValue = document.querySelector("#user-input").value.toLowerCase()
+  
+        const languageToTranslateFrom = document.querySelector("#language-selector-from").value
+        const languageToTranslateTo = document.querySelector("#language-selector-to").value
+  
+        const languageFrom = languageCodesObject[`${languageToTranslateFrom}`]
+        const languageTo = languageCodesObject[`${languageToTranslateTo}`]
+  
+        if(toBeTranslatedValue !== ""){
+          apiFetch.getAll(toBeTranslatedValue, languageFrom, languageTo)
+        }
+  
+        else{
+          const translatedPhrase = "I'm sorry, the phrase you entered is not in our dictionary! Please, try another phrase :)"
+          speechSynthesis.speak(new SpeechSynthesisUtterance(translatedPhrase))
+          document.querySelector("#translator-container").innerHTML += `
+          <p>${translatedPhrase}</p>`
+        }
+        }
+    })
+  

--- a/style.css
+++ b/style.css
@@ -53,3 +53,8 @@ header{
     display: flex;
     background-image: url("https://cdn.pixabay.com/photo/2018/03/20/18/23/cartography-3244166_960_720.png");
 }
+
+.btn-outline-light{
+    padding: 1rem;
+    border-radius: 5em;
+}


### PR DESCRIPTION
What I did:
- created a branch with full translator functionality
- added a Universal Language Translator page
- added 3 functions to DOMPrinter (buildUniversalTranslatorContainer, buildLanguageOptionsContainer and apiFetch)
- executed functions on all pages (commented out prev. translator execution w/ limited dictionary)

What you should see:
- 6 working links on the nav bar
- 5 pages with a working translator
- 4 language pages with an appropriate language translator
- 1 page with universal language translator with options to choose from 93 languages to translate from and into (however, there are limited voice-speech-options. some languages don't have voices so they default to the english voice)